### PR TITLE
Task spigot builds newest with fixed version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -55,7 +55,8 @@ RUN apt update
 ARG globalOpenJdkOptDirectoryName
 
 # Version
-ENV VERSION="1.20.5"
+# Update: https://www.minecraft.net/de-de/download/server
+ENV VERSION="1.20.6"
 
 # Custom metadata
 LABEL com.chris82111.minecraft.game.version=${VERSION}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,5 @@
 # syntax=docker/dockerfile:1
 
-#Linux, you can use the windows command a well
-#docker exec minecraftVanillaU /bin/sh -c 'echo "/say hello" >> stdin.pipe'
-
-#Windows
-#docker exec minecraftVanillaU /bin/sh -c "echo '/say hello' >> stdin.pipe"
-
 #------------------------------------------------------------------------------
 ### global variables
 #------------------------------------------------------------------------------

--- a/README.md
+++ b/README.md
@@ -22,13 +22,13 @@ After cloning the repository or downloading the Dockerfile, the image and the co
 Command to create the image (the creation takes about 215 seconds):
 
 ```sh
-docker build --build-arg="JAVA_PARAMETER=-Xmx1024M -Xms1024M" --build-arg="START_SPIGOT=false" -t minecraft_via_docker:1.20.5 .
+docker build --build-arg="JAVA_PARAMETER=-Xmx1024M -Xms1024M" --build-arg="START_SPIGOT=false" -t minecraft_via_docker:1.20.6 .
 ```
 
 Command to create the container without executing it:
 
 ```sh
-docker container create -it --name mcContainer -p 25565:25565 --mount type=bind,source="$(pwd)"/minecraft,target=/minecraft --env EULA=true minecraft_via_docker:1.20.5 sh
+docker container create -it --name mcContainer -p 25565:25565 --mount type=bind,source="$(pwd)"/minecraft,target=/minecraft --env EULA=true minecraft_via_docker:1.20.6 sh
 ```
 
 Start:


### PR DESCRIPTION
- Spigot 1.20.5 has been completely replaced by 1.20.6
- If you select version 1.20.5, the output file will be version 1.20.6
- Therefore, renaming will fail and the build process will be cancelled
- The README.md file has been updated